### PR TITLE
filtered navbar items based on account type

### DIFF
--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -114,7 +114,7 @@ const Navbar: React.FC = () => {
   const renderMenuItems = () => {
     // TODO: conditionally render based on profile type
     return menuItems.map((menu) => {
-      if (menu.authenticated) {
+      if (menu.authenticated && menu.canView) {
         return loggedInUser && <MenuItem key={menu.resource} {...menu} />;
       } else {
         return !loggedInUser && <MenuItem key={menu.resource} {...menu} />;


### PR DESCRIPTION
### What this PR does (required):
-filters and renders the navbar items based on authetication state and canView available in the array. if canView is null , it will not render.

### Screenshots / Videos (front-end only):

### Any information needed to test this feature (required):

### Any issues with the current functionality (optional):
-