### PR TITLE
design responsive page for navbar, profile page and booking page for …

### DIFF
--- a/client/src/components/AuthPageWrapper/AuthPageWrapper.tsx
+++ b/client/src/components/AuthPageWrapper/AuthPageWrapper.tsx
@@ -25,7 +25,7 @@ const AuthPageWrapper: React.FC<AuthPageWrapperProps> = ({ header, children }) =
       <AuthPageHeader header={header} />
       <Box
         sx={{
-          width: 350,
+          maxWidth: 350,
           margin: '0 auto',
         }}
       >

--- a/client/src/components/FormInput/FormInput.tsx
+++ b/client/src/components/FormInput/FormInput.tsx
@@ -12,6 +12,7 @@ const StyledInput = styled(InputBase)(({ theme }) => ({
     width: '100%',
     padding: '15px',
   },
+  width: '100%',
 }));
 
 interface FormInputProps {

--- a/client/src/components/ManageBookings/BookingCalenderWrapper/BookingCalenderWrapper.tsx
+++ b/client/src/components/ManageBookings/BookingCalenderWrapper/BookingCalenderWrapper.tsx
@@ -54,7 +54,7 @@ const sortedBookings = sortBookingDates(mockBookings);
 
 function BookingCalendarWrapper(): JSX.Element {
   return (
-    <Box>
+    <Box sx={{ width: '100%', position: 'center' }}>
       <BookingCalendar firstBooking={nextBooking} upcomingBookings={sortedBookings} />
     </Box>
   );

--- a/client/src/components/ManageBookings/BookingWrapper/BookingWrapper.tsx
+++ b/client/src/components/ManageBookings/BookingWrapper/BookingWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Grid } from '@mui/material';
 import CurrentBookingCard from '../CurrentBooking/CurrentBookingCard';
 import BookingCard from '../BookingCard/BookingCard';
 import useStyles from './useStyles';
@@ -10,18 +10,20 @@ const BookingWrapper = (): JSX.Element => {
   const array = Array.from(Array(3).keys());
 
   return (
-    <Box className={classes.wrapper}>
-      <Box className={classes.contentWrapper}>
-        <Typography className={classes.sectionHeader}>current Bookings</Typography>
-        {array.map((item, i) => (
-          <BookingCard key={i} />
-        ))}
-        <Typography className={classes.sectionHeader}>past Bookings</Typography>
-        {array.map((item, i) => (
-          <BookingCard key={i} />
-        ))}
+    <Grid xs={12} sm={3} item>
+      <Box className={classes.wrapper}>
+        <Box className={classes.contentWrapper}>
+          <Typography className={classes.sectionHeader}>current Bookings</Typography>
+          {array.map((item, i) => (
+            <BookingCard key={i} />
+          ))}
+          <Typography className={classes.sectionHeader}>past Bookings</Typography>
+          {array.map((item, i) => (
+            <BookingCard key={i} />
+          ))}
+        </Box>
       </Box>
-    </Box>
+    </Grid>
   );
 };
 

--- a/client/src/components/ManageBookings/BookingWrapper/useStyles.ts
+++ b/client/src/components/ManageBookings/BookingWrapper/useStyles.ts
@@ -11,7 +11,7 @@ const useStyles = makeStyles(() => ({
     margin: '0px auto',
     backgroundColor: 'rgb(255, 255, 255)',
     '@media(max-width: 767px)': {
-      width: '200px',
+      width: '100%',
       alignItems: 'center',
       margin: '0px auto',
     },

--- a/client/src/components/ManageBookings/CurrentBooking/CurrentBookingCard.tsx
+++ b/client/src/components/ManageBookings/CurrentBooking/CurrentBookingCard.tsx
@@ -1,31 +1,33 @@
-import { Typography, Box } from '@mui/material';
+import { Typography, Box, Grid } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import useStyles from './useStyles';
 
 const CurrentBookingCard = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <Box component="div" className={classes.cardWrapper}>
-      <SettingsIcon className={classes.icon} />
-      <Typography component="div" className={classes.title}>
-        your current booking
-      </Typography>
-      <Typography variant="h6" className={classes.date}>
-        8 April 2020, 7-9 PM
-      </Typography>
+    <Grid xs={12} sm={3} item>
+      <Box component="div" className={classes.cardWrapper}>
+        <SettingsIcon className={classes.icon} />
+        <Typography component="div" className={classes.title}>
+          your current booking
+        </Typography>
+        <Typography variant="h6" className={classes.date}>
+          8 April 2020, 7-9 PM
+        </Typography>
 
-      <Box className={classes.details}>
-        <Typography component="div" className={classes.image}>
-          <img src="https://cdn.pixabay.com/photo/2021/09/12/18/07/robin-6619184_960_720.jpg" alt="Image" />
-        </Typography>
-        <Typography className={classes.name} sx={{ fontSize: '18px', fontWeight: 'bold' }}>
-          Muhamad
-        </Typography>
-        <Typography className={classes.name} sx={{ fontSize: '18px', fontWeight: 'bold', paddingLeft: '10px' }}>
-          Rashid
-        </Typography>
+        <Box className={classes.details}>
+          <Typography component="div" className={classes.image}>
+            <img src="https://cdn.pixabay.com/photo/2021/09/12/18/07/robin-6619184_960_720.jpg" alt="Image" />
+          </Typography>
+          <Typography className={classes.name} sx={{ fontSize: '18px', fontWeight: 'bold' }}>
+            Muhamad
+          </Typography>
+          <Typography className={classes.name} sx={{ fontSize: '18px', fontWeight: 'bold', paddingLeft: '10px' }}>
+            Rashid
+          </Typography>
+        </Box>
       </Box>
-    </Box>
+    </Grid>
   );
 };
 

--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -9,6 +9,7 @@ import {
   Menu,
   MenuItem as DropdownMenuItem,
   styled,
+  useMediaQuery,
 } from '@mui/material';
 import clsx from 'clsx';
 import React, { useState } from 'react';
@@ -94,7 +95,7 @@ const Navbar: React.FC = () => {
   const location = useLocation();
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { loggedInUser, logout } = useAuth();
+  const { loggedInUser, profile, logout } = useAuth();
   const open = Boolean(anchorEl);
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -121,71 +122,157 @@ const Navbar: React.FC = () => {
     });
   };
 
+  const matches = useMediaQuery('(min-width:1200px)');
+
   return (
     <Grid
       className={clsx(classes.navbar, location.pathname === '/' && classes.transparentNavbar)}
       justifyContent="space-between"
       alignItems="center"
+      width="100%"
       container
     >
-      <Grid xs={4} md={6} item>
+      <Grid xs={6} sm={4} item>
         <img className={classes.navbarLogo} src={lovingSitterLogo} />
       </Grid>
-      <Grid xs={8} md={6} item>
-        <Grid container alignItems="center" gap={2} justifyContent="flex-end">
-          {renderMenuItems()}
-          {loggedInUser && (
-            <Grid xs={2} item>
-              <>
-                <IconButton
-                  size="large"
-                  aria-label="account profile picture"
-                  aria-controls="menu-navbar"
-                  arais-haspopup="true"
-                  onClick={handleMenuOpen}
-                  color="inherit"
-                >
-                  <img style={{ width: 50 }} src={`https://robohash.org/${loggedInUser.email}`} />
-                </IconButton>
-                <Menu
-                  id="menu-appbar"
-                  anchorEl={anchorEl}
-                  anchorOrigin={{
-                    vertical: 'bottom',
-                    horizontal: 'right',
-                  }}
-                  keepMounted
-                  transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                  }}
-                  open={open}
-                  onClose={handleClose}
-                >
-                  <DropdownMenuItem component={NavLink} to="/profile/settings" onClick={handleClose}>
-                    <ListItemIcon>
-                      <Settings fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText> Settings</ListItemText>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem component={NavLink} to="/profile/settings/profile-photo" onClick={handleClose}>
-                    <ListItemIcon>
-                      <Person fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>Profile</ListItemText>
-                  </DropdownMenuItem>
-                  <Divider />
-                  <DropdownMenuItem onClick={handleLogout}>
-                    <ListItemIcon>
-                      <Logout fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>Logout</ListItemText>
-                  </DropdownMenuItem>
-                </Menu>
-              </>
-            </Grid>
-          )}
-        </Grid>
+
+      <Grid xs={6} sm={4} item>
+        {matches ? (
+          <Grid container alignItems="center" gap={2} justifyContent="flex-end">
+            {renderMenuItems()}
+            {loggedInUser && (
+              <Grid xs={2} item>
+                <>
+                  <IconButton
+                    size="large"
+                    aria-label="account profile picture"
+                    aria-controls="menu-navbar"
+                    arais-haspopup="true"
+                    onClick={handleMenuOpen}
+                    color="inherit"
+                  >
+                    <img style={{ width: 50 }} src={`https://robohash.org/${loggedInUser.email}`} />
+                  </IconButton>
+                  <Menu
+                    id="menu-appbar"
+                    anchorEl={anchorEl}
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'right',
+                    }}
+                    keepMounted
+                    transformOrigin={{
+                      vertical: 'top',
+                      horizontal: 'right',
+                    }}
+                    open={open}
+                    onClose={handleClose}
+                  >
+                    <DropdownMenuItem component={NavLink} to="/profile/settings" onClick={handleClose}>
+                      <ListItemIcon>
+                        <Settings fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Settings</ListItemText>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleClose}>
+                      <ListItemIcon>
+                        <Person fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Profile</ListItemText>
+                    </DropdownMenuItem>
+                    <Divider />
+                    <DropdownMenuItem onClick={handleLogout}>
+                      <ListItemIcon>
+                        <Logout fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Logout</ListItemText>
+                    </DropdownMenuItem>
+                  </Menu>
+                </>
+              </Grid>
+            )}
+          </Grid>
+        ) : (
+          <Grid container alignItems="center" gap={2} justifyContent="flex-end">
+            {loggedInUser && (
+              <Grid xs={3} item>
+                <>
+                  <IconButton
+                    size="large"
+                    aria-label="account profile picture"
+                    aria-controls="menu-navbar"
+                    arais-haspopup="true"
+                    onClick={handleMenuOpen}
+                    color="inherit"
+                  >
+                    <img style={{ width: 50 }} src={`https://robohash.org/${loggedInUser.email}`} />
+                  </IconButton>
+                  <Menu
+                    id="menu-appbar"
+                    anchorEl={anchorEl}
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'right',
+                    }}
+                    keepMounted
+                    transformOrigin={{
+                      vertical: 'top',
+                      horizontal: 'right',
+                    }}
+                    open={open}
+                    onClose={handleClose}
+                  >
+                    <DropdownMenuItem component={NavLink} to="/dashboard" onClick={handleClose}>
+                      <ListItemIcon>
+                        <Person fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Become a sitter</ListItemText>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleClose}>
+                      <ListItemIcon>
+                        <Person fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>My job</ListItemText>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleClose}>
+                      <ListItemIcon>
+                        <Person fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>My sitter</ListItemText>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleClose}>
+                      <ListItemIcon>
+                        <Person fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Message</ListItemText>
+                    </DropdownMenuItem>
+
+                    <Divider />
+                    <DropdownMenuItem component={NavLink} to="/profile/settings" onClick={handleClose}>
+                      <ListItemIcon>
+                        <Settings fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Settings</ListItemText>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleClose}>
+                      <ListItemIcon>
+                        <Person fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Profile</ListItemText>
+                    </DropdownMenuItem>
+                    <Divider />
+                    <DropdownMenuItem onClick={handleLogout}>
+                      <ListItemIcon>
+                        <Logout fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Logout</ListItemText>
+                    </DropdownMenuItem>
+                  </Menu>
+                </>
+              </Grid>
+            )}
+          </Grid>
+        )}
       </Grid>
     </Grid>
   );

--- a/client/src/components/SettingsWrapper/SettingsWrapper.tsx
+++ b/client/src/components/SettingsWrapper/SettingsWrapper.tsx
@@ -10,7 +10,7 @@ const SettingsWrapper: React.FC<SettingsWrapperProps> = ({ children }) => {
     <Box
       sx={{
         background: '#fff',
-        padding: 8,
+        padding: 2,
         boxShadow:
           '0px 1.7px 4px rgba(0, 0, 0, 0.01), 0px 4.6px 11.1px rgba(0, 0, 0, 0.015), 0px 11.2px 26.8px rgba(0, 0, 0, 0.02),0px 37px 89px rgba(0, 0, 0, 0.03)',
       }}

--- a/client/src/pages/BookingPage/BookingPage.tsx
+++ b/client/src/pages/BookingPage/BookingPage.tsx
@@ -16,7 +16,7 @@ const BookingsPage = (): JSX.Element => {
           <BookingWrapper />
         </Box>
       </Grid>
-      <Grid xs={5} md={5} lg={5} item>
+      <Grid xs={10} md={5} lg={5} item>
         <Box className={classes.boxMargin}>
           <BookingCalendarWrapper />
         </Box>

--- a/client/src/pages/NotFound/NotFound.tsx
+++ b/client/src/pages/NotFound/NotFound.tsx
@@ -15,7 +15,7 @@ export default function NotFound(): JSX.Element {
 
   return (
     <PageContainer>
-      <Box sx={{ width: '50%', margin: '0 auto', textAlign: 'center' }}>
+      <Box sx={{ width: '100%', margin: '0 auto', textAlign: 'center' }}>
         <Typography
           sx={{
             color: 'primary.main',
@@ -25,7 +25,7 @@ export default function NotFound(): JSX.Element {
         >
           Sorry we couldn&apos;t get that page.
         </Typography>
-        <Box sx={{ width: 600, margin: '20px auto' }}>
+        <Box sx={{ width: '100%', margin: '20px auto' }}>
           <img className={classes.image} src={dogNotFound} />
         </Box>
       </Box>

--- a/client/src/pages/Settings/EditProfile/EditProfile.tsx
+++ b/client/src/pages/Settings/EditProfile/EditProfile.tsx
@@ -8,19 +8,34 @@ import { User } from '../../../interface/User';
 import { Profile } from '../../../interface/Profile';
 
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
-import { makeStyles } from '@mui/styles';
+import { createStyles, makeStyles } from '@mui/styles';
 import editProfile from '../../../helpers/APICalls/editProfile';
 import { useSnackBar } from '../../../context/useSnackbarContext';
+import { Theme } from '@mui/material';
 
-const useStyles = makeStyles({
-  dateInput: {
-    borderRadius: 8,
-    border: '1px solid #dbdbdb',
-    fontSize: 16,
-    width: '100%',
-    padding: '15px',
-  },
-});
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    dateInput: {
+      borderRadius: 8,
+      border: '1px solid #dbdbdb',
+      fontSize: 16,
+      width: '100%',
+      padding: '15px',
+    },
+    header: {
+      [theme.breakpoints.down('sm')]: {
+        width: '100px',
+      },
+    },
+    box: {
+      width: 600,
+      margin: '0 auto',
+      [theme.breakpoints.down('sm')]: {
+        width: 300,
+      },
+    },
+  }),
+);
 
 interface EditProfileProps {
   header: string;
@@ -77,8 +92,7 @@ const EditProfile: React.FC<EditProfileProps> = ({ header, currentUser, currentP
   return (
     <Box
       sx={{
-        width: 600,
-        margin: '0 auto',
+        width: '100%',
       }}
     >
       <SettingHeader header={header} />

--- a/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
@@ -26,7 +26,7 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser }) => {
 
   return (
     <Box sx={{ textAlign: 'center' }}>
-      <SettingHeader header="Availability" />
+      <SettingHeader header="Profile Photo" />
       <Avatar
         id="photo"
         sx={{
@@ -44,8 +44,8 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser }) => {
           fontSize: '14px',
           marginTop: '25px',
           color: '#aaaaaa',
-          marginLeft: 25,
-          marginRight: 25,
+
+          width: '100%',
         }}
       >
         Be sure to use a photo that <br />

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -59,12 +59,12 @@ export default function Settings(): JSX.Element {
 
   return (
     <PageContainer>
-      <Grid sx={{ width: '75%', margin: '0 auto' }} container>
-        <Grid xs={3} item>
+      <Grid sx={{ width: '90%', margin: '0 auto' }} container>
+        <Grid xs={9} sm={3} item>
           {settingsMenu.map((item) => (
             <Box
               sx={{
-                margin: '20px 0',
+                margin: '20px 20px',
               }}
               key={item.name}
             >
@@ -87,7 +87,7 @@ export default function Settings(): JSX.Element {
             </Box>
           ))}
         </Grid>
-        <Grid xs={9} item>
+        <Grid xs={12} sm={9} item>
           <Switch>
             <Route exact path="/profile/settings">
               <Redirect to="/profile/settings/edit-profile" />

--- a/client/src/pages/StripeConnect/StripeConnect.tsx
+++ b/client/src/pages/StripeConnect/StripeConnect.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from '@mui/material';
+import { Box, Button, Grid } from '@mui/material';
 import SettingHeader from '../../components/SettingsHeader/SettingsHeader';
 import stripeConnect from '../../helpers/APICalls/stripeConnect';
 
@@ -9,18 +9,20 @@ const StripeConnect = (): JSX.Element => {
 
   return (
     <>
-      <SettingHeader header="Payment Methods" />
-      <Box sx={{ width: '100%', position: 'relative', left: '-30px' }}>
-        <Button
-          variant="outlined"
-          sx={{ padding: '20px', fontWeight: 'bold' }}
-          onClick={() => {
-            createStripeAccount();
-          }}
-        >
-          Stripe Connect
-        </Button>
-      </Box>
+      <Grid xs={12} sm={3} item>
+        <SettingHeader header="Payment Methods" />
+        <Box sx={{ width: '100%', position: 'center' }}>
+          <Button
+            variant="outlined"
+            sx={{ padding: '20px', fontWeight: 'bold' }}
+            onClick={() => {
+              createStripeAccount();
+            }}
+          >
+            Stripe Connect
+          </Button>
+        </Box>
+      </Grid>
     </>
   );
 };


### PR DESCRIPTION
…mobile and desktop

### What this PR does (required):
- design responsive page for edit profile, profile page, booking and setting for mobile and desktop page

### Screenshots / Videos (front-end only):
- availability

![Screen Shot 2022-02-05 at 12 10 36 AM](https://user-images.githubusercontent.com/23616272/154188429-57ed93d4-3c09-4d1b-9e2b-ee6cf1753d70.png)


![Screen Shot 2022-02-05 at 12 00 37 AM](https://user-images.githubusercontent.com/23616272/154188440-b983665b-729d-4b76-ba6a-e8943ca5422b.png)

-my job 

<img width="196" alt="Screen Shot 2022-02-16 at 11 03 24 AM" src="https://user-images.githubusercontent.com/23616272/154188543-b7f541dd-346e-4d9d-af33-6b12fa256e50.png">

-edit profile
<img width="1390" alt="Screen Shot 2022-02-16 at 11 03 47 AM" src="https://user-images.githubusercontent.com/23616272/154188578-4cc6eb0b-3e2b-4288-abcf-3e58f73714ec.png">

<img width="210" alt="Screen Shot 2022-02-16 at 11 03 54 AM" src="https://user-images.githubusercontent.com/23616272/154188586-7a305ecf-f7aa-4eab-ab37-553f5918ad64.png">


- page not found


<img width="208" alt="Screen Shot 2022-02-16 at 11 04 36 AM" src="https://user-images.githubusercontent.com/23616272/154188642-87168095-7c32-4e35-9fc0-158a0c37f5c5.png">

- profile photo
<img width="1410" alt="Screen Shot 2022-02-16 at 11 05 01 AM" src="https://user-images.githubusercontent.com/23616272/154188809-f5b7dd8d-6776-467e-ad72-a8d26e4ee356.png">



<img width="209" alt="Screen Shot 2022-02-16 at 11 05 10 AM" src="https://user-images.githubusercontent.com/23616272/154188837-d1655743-1aa0-40d8-b911-aec00f29a613.png">





### Any issues with the current functionality (optional):
- will do the hamburger icon after, now each component will take 12 grid when size become xs